### PR TITLE
Fix: Recognize container that uses multiple DBs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN \
 
 RUN \
     apt-get -y update && \
-    apt-get -y install mydumper && \
+    apt-get -y install mydumper git sudo && \
     rm -rf /var/lib/apt/lists/*
 
 #

--- a/init.sh
+++ b/init.sh
@@ -2,7 +2,7 @@
 set -e
 
 #
-# Retreive and check mode, which can either be "BACKUP" or "RESTORE".
+# Retreive and check mode, which can either be "BACKUP", "COMPRESSED_BACKUP" or "RESTORE".
 # Based on the mode, different default options will be set.
 #
 
@@ -10,6 +10,9 @@ MODE=${MODE:-BACKUP}
  
 case "${MODE^^}" in
     'BACKUP')
+        OPTIONS=${OPTIONS:-}
+        ;;
+    'COMPRESSED_BACKUP')
         OPTIONS=${OPTIONS:--c}
         ;;
     'RESTORE')
@@ -103,7 +106,7 @@ echo "${MODE^^}"
 echo "======="
 echo
 
-if [[ "${MODE^^}" == "BACKUP" ]]
+if [[ "${MODE^^}" == "BACKUP" ]] || [[ "${MODE^^}" == "COMPRESSED_BACKUP" ]]
 then
 
     printf "===> Creating base directory... "

--- a/init.sh
+++ b/init.sh
@@ -47,7 +47,7 @@ echo
 # Display the container informations on standard out.
 #
 
-CONTAINER=$(export | sed -nr "/ENV_MYSQL_DATABASE/{s/^.+ -x (.+)_ENV.+/\1/p;q}")
+CONTAINER=$(export | sed -nr "/ENV_MYSQL_ROOT_PASSWORD/{s/^.+ -x (.+)_ENV.+/\1/p;q}")
 
 if [[ -z "${CONTAINER}" ]]
 then
@@ -86,7 +86,14 @@ umask ${UMASK}
 # Building common CLI options to use for mydumper and myloader.
 #
 
-CLI_OPTIONS="-v 3 -h ${!DB_ADDR} -P ${!DB_PORT} -u root -p ${!DB_PASS} -B ${!DB_NAME} ${OPTIONS}"
+CLI_OPTIONS="-v 3 -h ${!DB_ADDR} -P ${!DB_PORT} -u root -p ${!DB_PASS} ${OPTIONS}"
+
+if [ -z "${!DB_NAME}" ]; then
+  echo "No DB_NAME available, backup all DBs"
+else
+  CLI_OPTIONS="-B ${!DB_NAME} ${CLI_OPTIONS}"
+fi
+
 
 #
 # When MODE is set to "BACKUP", then mydumper has to be used to backup the database.


### PR DESCRIPTION
The docker container doesn't work with my linked in mariadb container. It has issues, because the env. variable `*_ENV_MYSQL_DATABASE` is not available.

I changed the behaviour so that this variable isn't required anymore. If it is not available mydumper will create a backup for all databases.