### PR TITLE
Update to Debian Buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,32 @@
-FROM debian:8
+FROM debian:buster
 
 MAINTAINER confirm IT solutions, dbarton
 
 #
-# Add user.
+# Ensure the correct variables are set for APT
 #
 
-RUN \
-    groupadd -g 666 mybackup && \
-    useradd -u 666 -g 666 -d /backup -c "MySQL Backup User" mybackup
-
-#
-# Install required packages.
-#
-
-RUN \
-    apt-get -y update && \
-    apt-get -y install mydumper && \
-    rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=noninteractive TERM=linux
 
 #
 # Install start script.
 #
 
 COPY init.sh /init.sh
-RUN chmod 750 /init.sh
+
+#
+# Add user and install required packages.
+#
+
+RUN \
+    groupadd -g 666 mybackup && \
+    useradd -u 666 -g 666 -d /backup -c "MySQL Backup User" mybackup && \
+    apt-get -y update && \
+    apt-get -y install mydumper && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    find /var/log -type f | while read f; do echo -ne '' > $f; done && \
+    chmod 750 /init.sh
 
 #
 # Set container settings.


### PR DESCRIPTION
* switches to the `debian:buster` image
* makes sure all the `RUN` commands are executed in one shot
* adds environment variables needed for apt